### PR TITLE
CSA-38 Update Readme with .env file information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,33 @@
 # core-backend
-START APP WITH DOCKER:
 
-Preparations:
+Before the start:
+ - 
+
+Please, make sure that you have a .env in the root folder. Feel free to specify values of environmental variables
+as you wish, but make sure that your .env file structured like .env.example.
+
+Start app with Docker:
  -
 
- - Migrate the DB:
+Firstly, you need to have Docker installed in your system. 
+If you haven't installed Docker yet, visit https://docs.docker.com/get-docker/ .
 
-        make make_migrate
-        make run_migrate
+Secondly, make sure to run commands below as a root user!
+You can use `sudo su` command to enter root mode.
+(Otherwise, you will receive 
+
+    permission denied while trying to connect to the Docker daemon socket at 
+    unix:///var/run/docker.sock: Get "http://...": dial unix /var/run/docker.sock: 
+    connect: permission denied
 
 
-Start:
- -
+Commands:
 
- - Build and run
+ - Build images and run application (use at the first setup to build app's images)
 
        make build_and_run
 
- - Run
+ - Run application
 
        make run_app
 
@@ -34,11 +44,29 @@ Additional:
 
  - Show logs 
 
-       sudo docker logs api
-       sudo docker logs db
+       docker logs api
+       docker logs db
+
+
+Database Migration:
+ -
+
+ - Make migrations of the DB:
+
+        make make_migrate
+
+ - Migrate the DB
+
+        make run_migrate
+
+
 
 Poetry:
  - 
+In this project used poetry environment, more info at https://python-poetry.org/
+
+Commands below will help you ensure that all needed packages are installed in your local environment 
+(and you won`t receive any import-related highlights in the IDE).
 
  - Load all needed packages
 
@@ -49,4 +77,4 @@ Poetry:
        poetry add <package_name>
 
 
-For more commands inspect Makefile
+For more commands inspect Makefile.


### PR DESCRIPTION
Added:
- a note about .env file
- a note about needing Docker installed
- a note about root privileges (with error text example)
- a note about Poetry and how to start working with it

Changed:
- sections order
- commands in "Show logs" section without 'sudo' according to CSA-39
- other minor improvements